### PR TITLE
Remove t_fprintf macros

### DIFF
--- a/src/relay_common.h
+++ b/src/relay_common.h
@@ -40,8 +40,6 @@
 } STMT_END
 
 #define _D(fmt, arg...) printf(FORMAT(fmt, ##arg))
-#define _TD(fmt, arg...) t_fprintf(THROTTLE_DEBUG, stdout, FORMAT(fmt, ##arg))
-#define _TE(fmt, arg...) t_fprintf(THROTTLE_ERROR, stdout, FORMAT(fmt, ##arg))
 
 #define SAYPX(fmt, arg...) SAYX(EXIT_FAILURE, fmt " { %s }", ##arg, errno ? strerror(errno) : "undefined error");
 #define _ENO(fmt, arg...) _E(fmt " { %s }", ##arg, errno ? strerror(errno) : "undefined error");


### PR DESCRIPTION
The throttling code was removed in c7bcf846db8c6c3cd4f062082c2259c549ab955f
