### PR TITLE
Remove extra ?: in boolean tests.

### DIFF
--- a/src/abort.c
+++ b/src/abort.c
@@ -24,10 +24,10 @@ uint32_t get_abort_val() {
 
 uint32_t not_aborted() {
     uint32_t v= RELAY_ATOMIC_READ(ABORT);
-    return (v & DIE) == 0 ? 1 : 0;
+    return (v & DIE) == 0;
 }
 
 uint32_t is_aborted() {
     uint32_t v= RELAY_ATOMIC_READ(ABORT);
-    return (v & DIE) == 0 ? 0 : 1;
+    return (v & DIE) == DIE;
 }


### PR DESCRIPTION
The standard already guarantees that the result of the equality and relational
operators return 0 or 1.
